### PR TITLE
Allow loopback addresses if the routerID itself is a loopback address.

### DIFF
--- a/pkg/packet/bgp/validate.go
+++ b/pkg/packet/bgp/validate.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Validator for BGPUpdate
-func ValidateUpdateMsg(m *BGPUpdate, rfs map[RouteFamily]BGPAddPathMode, isEBGP bool, isConfed bool) (bool, error) {
+func ValidateUpdateMsg(m *BGPUpdate, rfs map[RouteFamily]BGPAddPathMode, isEBGP bool, isConfed bool, loopbackAllowed bool) (bool, error) {
 	var strongestError error
 
 	eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
@@ -31,7 +31,7 @@ func ValidateUpdateMsg(m *BGPUpdate, rfs map[RouteFamily]BGPAddPathMode, isEBGP 
 			seen[a.GetType()] = a
 			newAttrs = append(newAttrs, a)
 			//check specific path attribute
-			ok, err := ValidateAttribute(a, rfs, isEBGP, isConfed)
+			ok, err := ValidateAttribute(a, rfs, isEBGP, isConfed, loopbackAllowed)
 			if !ok {
 				msgErr := err.(*MessageError)
 				if msgErr.ErrorHandling == ERROR_HANDLING_SESSION_RESET {
@@ -81,7 +81,7 @@ func ValidateUpdateMsg(m *BGPUpdate, rfs map[RouteFamily]BGPAddPathMode, isEBGP 
 	return strongestError == nil, strongestError
 }
 
-func ValidateAttribute(a PathAttributeInterface, rfs map[RouteFamily]BGPAddPathMode, isEBGP bool, isConfed bool) (bool, error) {
+func ValidateAttribute(a PathAttributeInterface, rfs map[RouteFamily]BGPAddPathMode, isEBGP bool, isConfed bool, loopbackAllowed bool) (bool, error) {
 	var strongestError error
 
 	eCode := uint8(BGP_ERROR_UPDATE_MESSAGE_ERROR)
@@ -169,7 +169,7 @@ func ValidateAttribute(a PathAttributeInterface, rfs map[RouteFamily]BGPAddPathM
 		}
 
 		//check IP address represents host address
-		if p.Value.IsLoopback() || isZero(p.Value) || isClassDorE(p.Value) {
+		if (!loopbackAllowed && p.Value.IsLoopback()) || isZero(p.Value) || isClassDorE(p.Value) {
 			eMsg := "invalid nexthop address"
 			data, _ := a.Serialize()
 			e := NewMessageErrorWithErrorHandling(eCode, eSubCodeBadNextHop, data, getErrorHandlingFromPathAttribute(p.GetType()), nil, eMsg)

--- a/pkg/server/fsm.go
+++ b/pkg/server/fsm.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -1053,7 +1054,7 @@ func (h *fsmHandler) recvMessageWithError() (*fsmMsg, error) {
 				h.fsm.lock.RLock()
 				rfMap := h.fsm.rfMap
 				h.fsm.lock.RUnlock()
-				ok, err := bgp.ValidateUpdateMsg(body, rfMap, isEBGP, isConfed)
+				ok, err := bgp.ValidateUpdateMsg(body, rfMap, isEBGP, isConfed, strings.HasPrefix(h.fsm.gConf.Config.RouterId, "127."))
 				if !ok {
 					handling = h.handlingError(m, err, useRevisedError)
 				}


### PR DESCRIPTION
This is for enabling testing of multiple GoBGP instances on the same host in the same process for testing.